### PR TITLE
Fix unhandled error NG0205 nei test sidebar con Angular 21.2.17

### DIFF
--- a/src/app/core/layout/sidebar/sidebar.spec.ts
+++ b/src/app/core/layout/sidebar/sidebar.spec.ts
@@ -99,7 +99,7 @@ describe('SidebarComponent', () => {
       ],
       providers: [
         { provide: ConfigService, useValue: mockConfigService },
-        provideRouter([]),
+        provideRouter([{ path: '**', children: [] }]),
         provideIcons({
           bootstrapCreditCard2Front, bootstrapCart3, bootstrapListUl,
           bootstrapBoxArrowRight, bootstrapShieldCheck, bootstrapPerson


### PR DESCRIPTION
Aggiunta rotta catch-all in provideRouter dello spec: il click sui routerLink avviava una navigazione che, senza rotte, falliva dopo la distruzione dell'injector del TestBed generando una unhandled rejection con il nuovo error handler di Angular 21.2.17.